### PR TITLE
Align product scripts with Printify response

### DIFF
--- a/fetch-products.js
+++ b/fetch-products.js
@@ -24,16 +24,26 @@ https
     res.on("end", () => {
       try {
         const raw = JSON.parse(data);
-        const products = raw.map((product) => {
+        // The Printify API wraps product data in a `data` array. Older versions
+        // of this script assumed the response itself was the array, causing a
+        // crash when accessing `raw.map`.  Normalise the shape so mapping works
+        // regardless of the response structure.
+        const items = Array.isArray(raw) ? raw : raw?.data || [];
+
+        const products = items.map((product) => {
           const variant = product.variants?.[0];
           const image = variant?.images?.[0]?.src || product.images?.[0]?.src;
           const price = (variant?.price || 0) / 100;
+
+          const productId = product.handle || product.id || "";
 
           return {
             title: product.title || "No title",
             image: image || "",
             price: price.toFixed(2),
-            link: `https://halal-hustler.printify.me/products/${product.handle || product.id}`,
+            link: productId
+              ? `https://halal-hustler.printify.me/products/${productId}`
+              : "",
           };
         });
 

--- a/products.html
+++ b/products.html
@@ -68,34 +68,43 @@
   </footer>
 
   <script>
-    fetch('products.json')
-      .then(res => res.json())
-      .then(products => {
-        const grid = document.getElementById('product-grid');
-        grid.innerHTML = ''; // clear loading text
+    fetch("products.json")
+      .then((res) => res.json())
+      .then((products) => {
+        const grid = document.getElementById("product-grid");
+        grid.innerHTML = ""; // clear loading text
 
-        products.forEach(product => {
-          const title = product.title || 'Untitled';
-          const price = product.variants && product.variants[0]?.price ? `$${product.variants[0].price}` : 'Price N/A';
-          const image = product.images && product.images[0]?.src ? product.images[0].src : 'placeholder.jpg';
-          const link = product.handle ? `https://halal-hustler.printify.me/product/${product.handle}` : '#';
+        products.forEach((product) => {
+          const title = product.title || "Untitled";
 
-          const div = document.createElement('div');
-          div.className = 'product';
+          // Products are stored in a simplified format by fetch-products.js.
+          // Prices may either be a number in cents or a pre-formatted string.
+          let price = product.price;
+          if (typeof price === "number") {
+            price = (price / 100).toFixed(2);
+          }
+          const formattedPrice = price ? `$${price}` : "Price N/A";
+
+          const image = product.image || "placeholder.jpg";
+          const link = product.link || "#";
+
+          const div = document.createElement("div");
+          div.className = "product";
           div.innerHTML = `
             <a href="${link}" target="_blank">
               <img src="${image}" alt="${title}">
             </a>
             <h3>${title}</h3>
-            <p class="price">${price}</p>
+            <p class="price">${formattedPrice}</p>
             <a class="btn" href="${link}" target="_blank">Shop Now</a>
           `;
           grid.appendChild(div);
         });
       })
-      .catch(error => {
-        document.getElementById('product-grid').innerHTML = '<p>Failed to load products. Please try again later.</p>';
-        console.error('Fetch error:', error);
+      .catch((error) => {
+        document.getElementById("product-grid").innerHTML =
+          "<p>Failed to load products. Please try again later.</p>";
+        console.error("Fetch error:", error);
       });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- normalize Printify API response and avoid creating invalid product links
- render simplified product data with robust price handling on the products page

## Testing
- `node --check fetch-products.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938eb9d95c833183fdc44bbb25f47c